### PR TITLE
chore: migrate Jenkinsfile to jenkins-lib-common@1.1.2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,11 +3,11 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 library(
-  identifier: 'jenkins-packages-build-library@1.0.4',
+  identifier: 'jenkins-lib-common@1.1.2',
   retriever: modernSCM([
     $class: 'GitSCMSource',
-    remote: 'git@github.com:zextras/jenkins-packages-build-library.git',
-    credentialsId: 'jenkins-integration-with-github-account'
+    credentialsId: 'jenkins-integration-with-github-account',
+    remote: 'git@github.com:zextras/jenkins-lib-common.git'
   ])
 )
 
@@ -29,22 +29,13 @@ pipeline {
     timeout(time: 1, unit: 'HOURS')
   }
 
-  parameters {
-    booleanParam defaultValue: false,
-      description: 'Whether to upload the packages in playground repository',
-      name: 'PLAYGROUND'
-  }
-
-  tools {
-    jfrog 'jfrog-cli'
-  }
-  
   stages {
-    stage('Build setup') {
+    stage('Setup') {
       steps {
         checkout scm
         script {
           gitMetadata()
+          properties(defaultPipelineProperties())
         }
       }
     }
@@ -75,9 +66,12 @@ pipeline {
     }
 
     stage('Upload artifacts') {
+      tools {
+        jfrog 'jfrog-cli'
+      }
       steps {
         uploadStage(
-          packages: yapHelper.getPackageNames(),
+          packages: yapHelper.resolvePackageNames(),
           rockySinglePkg: true,
           ubuntuSinglePkg: true,
         )


### PR DESCRIPTION
Migrates Jenkinsfile from deprecated `jenkins-packages-build-library@1.0.4` to `jenkins-lib-common@1.1.2`.

## Changes

- **Library migration**: Updated to `jenkins-lib-common@1.1.2` from `jenkins-packages-build-library@1.0.4`
- **Parameters cleanup**: Removed unused `PLAYGROUND` parameter
- **Setup stage enhancement**: Renamed `Checkout` → `Setup` and added `properties(defaultPipelineProperties())` call
- **Tool scoping**: Moved `jfrog` tool declaration from pipeline-level to `Upload artifacts` stage

```groovy
// Before: global tools declaration
pipeline {
    tools {
        jfrog 'jfrog-cli'
    }
}

// After: stage-scoped tool
stage('Upload artifacts') {
    tools {
        jfrog 'jfrog-cli'
    }
    steps { ... }
}
```

Resolve: [IN-959](https://zextras.atlassian.net/browse/IN-959)

[IN-959]: https://zextras.atlassian.net/browse/IN-959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ