### PR TITLE
chore(release): 0.2.6 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## [0.2.6](https://github.com/zextras/carbonio-ws-collaboration-db/compare/v0.2.5...v0.2.6) (2026-02-23)
+
 ## [](https://github.com/zextras/carbonio-ws-collaboration-db/compare/v0.2.5...v) (2026-01-08)
 ## [0.2.5](https://github.com/zextras/carbonio-ws-collaboration-db/compare/0.2.2...v0.2.5) (2025-11-17)
 

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname="carbonio-ws-collaboration-db"
-pkgver="0.2.5"
+pkgver="0.2.6"
 pkgrel="SNAPSHOT"
 pkgdesc="Carbonio Workstream Collaboration DB sidecar"
 maintainer="Zextras <packages@zextras.com>"


### PR DESCRIPTION
🤖 Automated release preparation for v0.2.6