### PR TITLE
chore: [CO-3496] define sidecar image for ws collaboration db

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,6 +57,18 @@ pipeline {
             }
         }
 
+        stage('Build container images') {
+            steps {
+                buildAndPublishDockerImage(
+                        projectName: 'carbonio-ws-collaboration-db-sidecar',
+                        dockerfile: 'docker/sidecar/Dockerfile',
+                        imageTitle: 'Carbonio Ws Collaboration DB Sidecar',
+                        imageDescription: 'Envoy Sidecar for Carbonio Ws Collaboration DB'
+                )
+            }
+        }
+
+
         stage('Build deb/rpm') {
             steps {
                 script {

--- a/docker/sidecar/Dockerfile
+++ b/docker/sidecar/Dockerfile
@@ -1,0 +1,32 @@
+FROM registry.dev.zextras.com/dev/carbonio-sidecar:latest
+
+# psql is needed by the bootstrap script to create the database
+RUN apt-get update && apt-get install -y postgresql-client openssl && rm -rf /var/lib/apt/lists/*
+
+# Service registration
+COPY package/carbonio-ws-collaboration-db.hcl /consul/config/
+
+# Setup files at the path the setup script expects
+COPY package/service-protocol.json /etc/carbonio/ws-collaboration-db/service-discover/
+COPY package/intentions.json       /etc/carbonio/ws-collaboration-db/service-discover/
+COPY package/policies.json         /etc/carbonio/ws-collaboration-db/service-discover/
+
+# Setup script
+COPY package/carbonio-ws-collaboration-db /usr/local/bin/carbonio-ws-collaboration-db
+RUN chmod +x /usr/local/bin/carbonio-ws-collaboration-db
+
+# Bootstrap script (creates DB user, database, saves credentials to consul KV)
+COPY package/carbonio-ws-collaboration-db-bootstrap /usr/local/bin/carbonio-ws-collaboration-db-bootstrap
+RUN chmod +x /usr/local/bin/carbonio-ws-collaboration-db-bootstrap
+
+# Entrypoint script
+COPY docker/sidecar/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ENV SERVICE_NAME=carbonio-ws-collaboration-db
+ENV PGPASSWORD=admin
+ENV POSTGRES_USER=admin
+ENV POSTGRES_HOST=localhost
+ENV POSTGRES_PORT=5432
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/docker/sidecar/entrypoint.sh
+++ b/docker/sidecar/entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -e
+
+echo '[sidecar] Waiting for consul agent...'
+until consul members >/dev/null 2>&1; do sleep 1; done
+echo '[sidecar] Consul agent ready.'
+
+echo '[sidecar] Waiting for postgres...'
+until pg_isready -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" >/dev/null 2>&1; do sleep 1; done
+until PGPASSWORD="$PGPASSWORD" psql -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" -U "$POSTGRES_USER" -w -c 'SELECT 1' >/dev/null 2>&1; do sleep 1; done
+echo '[sidecar] Postgres ready.'
+
+consul services register /consul/config/*.hcl
+
+echo '[sidecar] Running setup...'
+carbonio-ws-collaboration-db setup || true
+
+echo '[sidecar] Running bootstrap...'
+carbonio-ws-collaboration-db-bootstrap "$POSTGRES_USER" "$POSTGRES_HOST" || true
+
+echo "[sidecar] Starting envoy for $SERVICE_NAME"
+exec consul connect envoy \
+  -sidecar-for="$SERVICE_NAME" \
+  -admin-bind=localhost:0


### PR DESCRIPTION
Adds the sidecar image for the db.
The entrypoint is basically a copy/paste of other db setups.

It's different from other sidecars, because db sidecars:
- create credentials and database  (need postgresql cli in order to run)
- register policies to Consul