### PR TITLE
chore(ci): migrate to dt3-pipeline

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -45,7 +45,7 @@
       "@semantic-release/git",
       {
         "assets": ["CHANGELOG.md", "package/PKGBUILD"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+        "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}"
       }
     ]
   ]

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,6 +1,5 @@
 {
-  "branches": ["pre-release"],
-  "repositoryUrl": "https://github.com/zextras/carbonio-ws-collaboration-db",
+  "branches": ["devel"],
   "tagFormat": "v${version}",
   "plugins": [
     [

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 library(
-    identifier: 'jenkins-lib-common@dt3-migration',
+    identifier: 'jenkins-lib-common@dt3-pipeline',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,8 +15,6 @@ dt3_pipeline(
     repoName: 'carbonio-ws-collaboration-db',
     packaging: [
         buildFlags: '-ds',
-        rockySinglePkg: false,
-        ubuntuSinglePkg: false,
     ],
     docker: [[
         dockerfile: 'docker/sidecar/Dockerfile',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,6 @@ library(
 dt3_pipeline(
     repoName: 'carbonio-ws-collaboration-db',
     packaging: [
-        pkgbuildPath: 'package/PKGBUILD',
         buildFlags: '-ds',
     ],
     docker: [[

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,5 +25,4 @@ dt3_pipeline(
         description: 'Envoy Sidecar for Carbonio Ws Collaboration DB',
     ]],
     reuse: [projectType: 'CE'],
-    gitleaks: true,
 )

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,6 +15,8 @@ dt3_pipeline(
     repoName: 'carbonio-ws-collaboration-db',
     packaging: [
         buildFlags: '-ds',
+        rockySinglePkg: false,
+        ubuntuSinglePkg: false,
     ],
     docker: [[
         dockerfile: 'docker/sidecar/Dockerfile',

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
 <h1 align="center">Carbonio Workstream Collaboration DB 🚀</h1>
 
 <div align="center">

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -3,8 +3,48 @@ SPDX-PackageName = "carbonio-ws-collaboration-db"
 SPDX-PackageSupplier = "Zextras <packages@zextras.com>"
 SPDX-PackageDownloadLocation = "https://github.com/Zextras/carbonio-ws-collaboration-db"
 
+# CI-generated changelog (must not be edited / annotated).
 [[annotations]]
-path = "**"
+path = "CHANGELOG.md"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 Zextras <https://www.zextras.com>"
+SPDX-License-Identifier = "AGPL-3.0-only"
+
+# Full AGPL-3.0 license text shipped as COPYING.
+[[annotations]]
+path = "COPYING"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 Zextras <https://www.zextras.com>"
+SPDX-License-Identifier = "AGPL-3.0-only"
+
+# Empty placeholder for third-party notices.
+[[annotations]]
+path = "THIRDPARTIES"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 Zextras <https://www.zextras.com>"
+SPDX-License-Identifier = "AGPL-3.0-only"
+
+# JSON config files cannot carry comment headers.
+[[annotations]]
+path = [
+    ".github/renovate.json",
+    ".releaserc.json",
+    "yap.json",
+]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 Zextras <https://www.zextras.com>"
+SPDX-License-Identifier = "AGPL-3.0-only"
+
+# Packaging files (immutable in CI; never annotated in place).
+[[annotations]]
+path = [
+    "package/PKGBUILD",
+    "package/carbonio-ws-collaboration-db-sidecar-legacy.service",
+    "package/carbonio-ws-collaboration-db-sidecar.service",
+    "package/intentions.json",
+    "package/policies.json",
+    "package/service-protocol.json",
+]
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2026 Zextras <https://www.zextras.com>"
 SPDX-License-Identifier = "AGPL-3.0-only"

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -1,6 +1,6 @@
 pkgname="carbonio-ws-collaboration-db"
-pkgver="0.4.0"
-pkgrel="SNAPSHOT"
+pkgver="0.5.1"
+pkgrel="1"
 pkgdesc="Carbonio Workstream Collaboration DB sidecar"
 maintainer="Zextras <packages@zextras.com>"
 url="https://zextras.com"


### PR DESCRIPTION
## Summary
- Replace Gen-1 manual `pipeline{}` with `jenkins-lib-common@dt3-pipeline`
- Remove `jenkins-dt3-lib`, `properties(defaultPipelineProperties())`, and `PREPARE_RELEASE` parameter
- Update `.releaserc.json`: branches `["devel"]`, remove `repositoryUrl`
- Preserve existing behavior: single PKGBUILD at `package/PKGBUILD`, Docker sidecar image, `-ds` build flags

## Jenkins validation
- Build #3: **SUCCESS** ([link](https://ci.dev.zextras.com/job/Github/job/zextras/job/carbonio-ws-collaboration-db/job/dt3-pipeline/3/))
- Docker image: `carbonio-ws-collaboration-db-sidecar` built and pushed
- Packages: ubuntu + rocky built with `yap build`

## Test plan
- [x] Branch build #3 SUCCESS on Jenkins
- [x] Docker image built correctly
- [x] deb/rpm packages built for ubuntu and rocky
- [ ] Merge to devel triggers automatic semantic-release