### PR TITLE
chore(ci): generate packages for every distro

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,9 +75,7 @@ pipeline {
                     buildPackages([
                         pkgbuildPath: 'package/PKGBUILD',
                         buildStageConfig: [
-                            buildFlags: ' -ds ',
-                            rockySinglePkg: true,
-                            ubuntuSinglePkg: true
+                            buildFlags: ' -ds '
                         ]
                     ])
                 }
@@ -93,9 +91,7 @@ pipeline {
             }
             steps {
                 uploadStage(
-                    packages: yapHelper.resolvePackageNames(),
-                    rockySinglePkg: true,
-                    ubuntuSinglePkg: true
+                    packages: yapHelper.resolvePackageNames()
                 )
             }
         }


### PR DESCRIPTION
CO-3709: remove rockySinglePkg and ubuntuSinglePkg directives to allow package generation for all distros