### PR TITLE
build: migrate to buildah (FQDN images + jenkins-lib-common@2.10.0)

### DIFF
--- a/docker/sidecar/Dockerfile
+++ b/docker/sidecar/Dockerfile
@@ -15,7 +15,7 @@
 # liblber-2.5, libsasl2, libreadline. Everything goes under /usr/lib (not /lib):
 # ubuntu jammy is usrmerged so /lib is a symlink to /usr/lib, and COPYing into
 # /lib/* fails on some buildkit versions ("cannot copy to non-directory").
-FROM --platform=$BUILDPLATFORM ubuntu:jammy AS pgclient
+FROM --platform=$BUILDPLATFORM docker.io/library/ubuntu:jammy AS pgclient
 ARG TARGETARCH
 RUN set -eux; \
     case "$TARGETARCH" in \


### PR DESCRIPTION
## Buildah migration

Replacing `docker buildx` with **buildah**, which requires fully-qualified image references.

### Changes
- **Dockerfiles:** fully-qualify base images (e.g. `alpine:3` -> `docker.io/library/alpine:3`). Multi-stage aliases and already-qualified refs untouched.
- **Jenkinsfile:** bump `jenkins-lib-common` to `@2.10.0`.

> Draft - part of org-wide buildah migration.