### PR TITLE
fix(ci): build packages for all distros

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,8 @@ dt3_pipeline(
     packaging: [
         pkgbuildPath: 'package/PKGBUILD',
         buildFlags: '-ds',
+        rockySinglePkg: false,
+        ubuntuSinglePkg: false,
     ],
     docker: [[
         dockerfile: 'docker/sidecar/Dockerfile',


### PR DESCRIPTION
Add `rockySinglePkg: false` and `ubuntuSinglePkg: false` to the `packaging:` map in `dt3_pipeline()` so packages are built for all supported distro variants instead of a single package per distro.

CO-3709